### PR TITLE
Safetensors Convert

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ src/                  # Python MLX implementation
   ts_projector.py     # MLPProjector
   opentslm_sp.py      # End-to-end model (includes interleave logic)
   sleep_dataset.py    # Sleep-EDF dataset loader (auto-downloads data)
-checkpoints/          # Trained PyTorch checkpoints
+checkpoints/          # Converted safetensors weights
 models/               # LLM base weights
 ```
 
@@ -38,13 +38,28 @@ be combined with these LoRA weights.
 
 ### 3. Download a checkpoint
 
-Download a trained checkpoint and place it in `checkpoints/`:
+Download a trained `.pt` checkpoint and place it in `checkpoints/`:
 
 | Checkpoint            | Task                             | Source                                                      |
 | --------------------- | -------------------------------- | ----------------------------------------------------------- |
 | `model_checkpoint.pt` | EEG / sleep stage classification | [HuggingFace](https://huggingface.co/OpenTSLM) |
 
-Each checkpoint contains trained encoder, projector, and LoRA adapter weights.
+Then run one-time conversion to safetensors:
+
+```bash
+# One-time conversion dependencies
+pip install torch peft safetensors
+
+python convert_checkpoint.py \
+  --input checkpoints/model_checkpoint.pt \
+  --output-prefix checkpoints/model_checkpoint
+```
+
+This writes:
+
+- `checkpoints/model_checkpoint.encoder.safetensors`
+- `checkpoints/model_checkpoint.projector.safetensors`
+- `checkpoints/model_checkpoint.lora.safetensors` (if LoRA exists)
 
 ## Running Inference
 

--- a/convert_checkpoint.py
+++ b/convert_checkpoint.py
@@ -1,0 +1,150 @@
+#
+# SPDX-FileCopyrightText: 2026 Stanford University, ETH Zurich, and the project authors (see CONTRIBUTORS.md)
+# SPDX-FileCopyrightText: 2026 This source file is part of the OpenTSLMMLX open-source project.
+#
+# SPDX-License-Identifier: MIT
+#
+
+"""One-time conversion from OpenTSLM PyTorch checkpoints to safetensors.
+
+Usage:
+    python convert_checkpoint.py \
+        --input checkpoints/model_checkpoint.pt \
+        --output-prefix checkpoints/model_checkpoint
+
+Outputs:
+    checkpoints/model_checkpoint.encoder.safetensors
+    checkpoints/model_checkpoint.projector.safetensors
+    checkpoints/model_checkpoint.lora.safetensors
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+import numpy as np
+from safetensors.numpy import save_file
+
+
+def _convert_encoder_weights(state_dict: dict) -> dict[str, np.ndarray]:
+    """Convert PyTorch TransformerCNNEncoder state_dict to MLX key/shape format."""
+    weights: dict[str, np.ndarray] = {}
+
+    # Conv1d: PyTorch [C_out, C_in, K] -> MLX [C_out, K, C_in]
+    weights["patch_embed.weight"] = state_dict["patch_embed.weight"].float().cpu().numpy().transpose(0, 2, 1)
+    weights["pos_embed"] = state_dict["pos_embed"].float().cpu().numpy()
+    weights["input_norm.weight"] = state_dict["input_norm.weight"].float().cpu().numpy()
+    weights["input_norm.bias"] = state_dict["input_norm.bias"].float().cpu().numpy()
+
+    num_layers = sum(
+        1 for k in state_dict if k.startswith("encoder.layers.") and k.endswith(".norm1.weight")
+    )
+    for i in range(num_layers):
+        pt_pfx = f"encoder.layers.{i}"
+        mlx_pfx = f"layers.{i}"
+
+        # Split fused QKV into separate Q, K, V projections.
+        in_proj_w = state_dict[f"{pt_pfx}.self_attn.in_proj_weight"].float().cpu().numpy()
+        in_proj_b = state_dict[f"{pt_pfx}.self_attn.in_proj_bias"].float().cpu().numpy()
+        d = in_proj_w.shape[1]
+
+        weights[f"{mlx_pfx}.self_attn.query_proj.weight"] = in_proj_w[:d]
+        weights[f"{mlx_pfx}.self_attn.key_proj.weight"] = in_proj_w[d : 2 * d]
+        weights[f"{mlx_pfx}.self_attn.value_proj.weight"] = in_proj_w[2 * d :]
+        weights[f"{mlx_pfx}.self_attn.query_proj.bias"] = in_proj_b[:d]
+        weights[f"{mlx_pfx}.self_attn.key_proj.bias"] = in_proj_b[d : 2 * d]
+        weights[f"{mlx_pfx}.self_attn.value_proj.bias"] = in_proj_b[2 * d :]
+
+        weights[f"{mlx_pfx}.self_attn.out_proj.weight"] = (
+            state_dict[f"{pt_pfx}.self_attn.out_proj.weight"].float().cpu().numpy()
+        )
+        weights[f"{mlx_pfx}.self_attn.out_proj.bias"] = (
+            state_dict[f"{pt_pfx}.self_attn.out_proj.bias"].float().cpu().numpy()
+        )
+
+        for name in ["linear1", "linear2"]:
+            for param in ["weight", "bias"]:
+                weights[f"{mlx_pfx}.{name}.{param}"] = (
+                    state_dict[f"{pt_pfx}.{name}.{param}"].float().cpu().numpy()
+                )
+
+        for name in ["norm1", "norm2"]:
+            for param in ["weight", "bias"]:
+                weights[f"{mlx_pfx}.{name}.{param}"] = (
+                    state_dict[f"{pt_pfx}.{name}.{param}"].float().cpu().numpy()
+                )
+
+    return weights
+
+
+def _convert_projector_weights(state_dict: dict) -> dict[str, np.ndarray]:
+    """Convert PyTorch MLPProjector state_dict to MLX key format."""
+    return {
+        "norm.weight": state_dict["projector.0.weight"].float().cpu().numpy(),
+        "norm.bias": state_dict["projector.0.bias"].float().cpu().numpy(),
+        "linear.weight": state_dict["projector.1.weight"].float().cpu().numpy(),
+        "linear.bias": state_dict["projector.1.bias"].float().cpu().numpy(),
+    }
+
+
+def _convert_lora_weights(state_dict: dict) -> dict[str, np.ndarray]:
+    """Convert PEFT LoRA keys/shapes to MLX LoRA keys/shapes.
+
+    PEFT stores:
+      - lora_A as [r, in]  -> MLX expects [in, r]
+      - lora_B as [out, r] -> MLX expects [r, out]
+    """
+    weights: dict[str, np.ndarray] = {}
+    for key, tensor in state_dict.items():
+        m = re.match(r"base_model\.model\.(.+)\.(lora_[AB])\.default\.weight", key)
+        if not m:
+            continue
+        mlx_key = f"{m.group(1)}.{m.group(2).lower()}"
+        weights[mlx_key] = tensor.float().cpu().numpy().T
+    return weights
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--input", required=True, help="Path to input .pt checkpoint")
+    parser.add_argument(
+        "--output-prefix",
+        required=True,
+        help="Output prefix (writes .encoder/.projector/.lora.safetensors)",
+    )
+    args = parser.parse_args()
+
+    import torch
+
+    ckpt_path = Path(args.input)
+    out_prefix = Path(args.output_prefix)
+    checkpoint = torch.load(ckpt_path, map_location="cpu", weights_only=False)
+
+    if "encoder_state" not in checkpoint or "projector_state" not in checkpoint:
+        raise ValueError("Checkpoint is missing 'encoder_state' or 'projector_state'")
+
+    encoder_weights = _convert_encoder_weights(checkpoint["encoder_state"])
+    projector_weights = _convert_projector_weights(checkpoint["projector_state"])
+    lora_weights = _convert_lora_weights(checkpoint.get("lora_state", {}))
+
+    encoder_path = str(out_prefix) + ".encoder.safetensors"
+    projector_path = str(out_prefix) + ".projector.safetensors"
+    lora_path = str(out_prefix) + ".lora.safetensors"
+
+    save_file(encoder_weights, encoder_path)
+    save_file(projector_weights, projector_path)
+    if lora_weights:
+        save_file(lora_weights, lora_path)
+
+    print(f"Wrote {encoder_path} ({len(encoder_weights)} tensors)")
+    print(f"Wrote {projector_path} ({len(projector_weights)} tensors)")
+    if lora_weights:
+        print(f"Wrote {lora_path} ({len(lora_weights)} tensors)")
+    else:
+        print("No LoRA tensors found; skipped .lora.safetensors output")
+
+
+if __name__ == "__main__":
+    main()

--- a/inference.py
+++ b/inference.py
@@ -18,7 +18,7 @@ from sleep_dataset import SleepEDFDataset
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--checkpoint", default="checkpoints/model_checkpoint.pt")
+    parser.add_argument("--checkpoint", default="checkpoints/model_checkpoint")
     parser.add_argument("--model", default="models/Llama-3.2-1B-bf16")
     parser.add_argument("--sample-idx", type=int, default=0)
     parser.add_argument("--max-new-tokens", type=int, default=300)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,5 @@
 mlx
 mlx-lm
-torch
-peft
 numpy
 pandas
 scikit-learn

--- a/src/opentslm_sp.py
+++ b/src/opentslm_sp.py
@@ -7,8 +7,6 @@
 
 """MLX OpenTSLMSP: end-to-end time-series language model."""
 
-import re
-
 import numpy as np
 import mlx.core as mx
 from mlx_lm import load
@@ -36,30 +34,30 @@ class OpenTSLMSP:
         self.patch_size = 4
 
     def load_from_file(self, path: str):
-        """Load trained encoder/projector/LoRA weights from a PyTorch checkpoint.
+        """Load pre-converted encoder/projector/LoRA safetensors weights.
 
-        TODO: Remove torch dependency by pre-converting checkpoints to safetensors.
-          Write a conversion script that applies all weight transforms.
+        Args:
+            path: prefix path used for:
+              {path}.encoder.safetensors
+              {path}.projector.safetensors
+              {path}.lora.safetensors (optional)
         """
-        import torch
+        encoder_state = mx.load(f"{path}.encoder.safetensors")
+        projector_state = mx.load(f"{path}.projector.safetensors")
 
-        checkpoint = torch.load(path, map_location="cpu", weights_only=False)
-
-        if "encoder_state" not in checkpoint or "projector_state" not in checkpoint:
-            raise ValueError("Checkpoint is missing 'encoder_state' or 'projector_state'")
-
-        max_patches = checkpoint["encoder_state"]["pos_embed"].shape[1]
+        max_patches = encoder_state["pos_embed"].shape[1]
         self.encoder = TransformerCNNEncoder(max_patches=max_patches)
-        encoder_weights = _convert_encoder_weights(checkpoint["encoder_state"])
-        self.encoder.load_weights(list(encoder_weights.items()))
+        self.encoder.load_weights(list(encoder_state.items()))
 
-        projector_weights = _convert_projector_weights(checkpoint["projector_state"])
-        self.projector.load_weights(list(projector_weights.items()))
+        self.projector.load_weights(list(projector_state.items()))
 
-        if checkpoint.get("lora_state"):
-            self._apply_lora(checkpoint["lora_state"])
+        try:
+            lora_state = mx.load(f"{path}.lora.safetensors")
+            self._apply_lora(lora_state)
+        except Exception:
+            pass
 
-        print(f"  Loaded model from epoch {checkpoint.get('epoch', '?')}")
+        print(f"  Loaded model from prefix: {path}")
 
     def _apply_lora(
         self,
@@ -78,18 +76,7 @@ class OpenTSLMSP:
             {"rank": lora_r, "scale": scale, "dropout": 0.0},
         )
 
-        # TODO: Remove this conversion once checkpoints are pre-converted to safetensors.
-        lora_weights = []
-        for key, tensor in lora_state.items():
-            m = re.match(r"base_model\.model\.(.+)\.(lora_[AB])\.default\.weight", key)
-            if not m:
-                continue
-
-            # PEFT lora_A [r, in] → MLX lora_a [in, r]
-            # PEFT lora_B [out, r] → MLX lora_b [r, out]
-            mlx_key = f"{m.group(1)}.{m.group(2).lower()}"
-            lora_weights.append((mlx_key, mx.array(tensor.float().numpy()).T))
-
+        lora_weights = list(lora_state.items())
         self.llm.load_weights(lora_weights, strict=False)
         print(f"  Applied LoRA: {len(lora_weights) // 2} modules, rank={lora_r}, alpha={lora_alpha}")
 
@@ -249,72 +236,3 @@ class OpenTSLMSP:
                 break
 
         return self.tokenizer.decode(tokens)
-
-
-def _convert_encoder_weights(state_dict: dict) -> dict:
-    """Convert PyTorch TransformerCNNEncoder state_dict to MLX format.
-
-    TODO: Remove once checkpoints are pre-converted to safetensors.
-    """
-    weights = {}
-
-    # Conv1d: PyTorch [C_out, C_in, K] -> MLX [C_out, K, C_in]
-    weights["patch_embed.weight"] = mx.array(
-        state_dict["patch_embed.weight"].numpy().transpose(0, 2, 1)
-    )
-    weights["pos_embed"] = mx.array(state_dict["pos_embed"].numpy())
-    weights["input_norm.weight"] = mx.array(state_dict["input_norm.weight"].numpy())
-    weights["input_norm.bias"] = mx.array(state_dict["input_norm.bias"].numpy())
-
-    num_layers = sum(
-        1 for k in state_dict if k.startswith("encoder.layers.") and k.endswith(".norm1.weight")
-    )
-    for i in range(num_layers):
-        pt_pfx = f"encoder.layers.{i}"
-        mx_pfx = f"layers.{i}"
-
-        # Split combined QKV -> separate Q, K, V
-        in_proj_w = state_dict[f"{pt_pfx}.self_attn.in_proj_weight"].numpy()
-        in_proj_b = state_dict[f"{pt_pfx}.self_attn.in_proj_bias"].numpy()
-        d = in_proj_w.shape[1]
-
-        weights[f"{mx_pfx}.self_attn.query_proj.weight"] = mx.array(in_proj_w[:d])
-        weights[f"{mx_pfx}.self_attn.key_proj.weight"] = mx.array(in_proj_w[d : 2 * d])
-        weights[f"{mx_pfx}.self_attn.value_proj.weight"] = mx.array(in_proj_w[2 * d :])
-        weights[f"{mx_pfx}.self_attn.query_proj.bias"] = mx.array(in_proj_b[:d])
-        weights[f"{mx_pfx}.self_attn.key_proj.bias"] = mx.array(in_proj_b[d : 2 * d])
-        weights[f"{mx_pfx}.self_attn.value_proj.bias"] = mx.array(in_proj_b[2 * d :])
-
-        weights[f"{mx_pfx}.self_attn.out_proj.weight"] = mx.array(
-            state_dict[f"{pt_pfx}.self_attn.out_proj.weight"].numpy()
-        )
-        weights[f"{mx_pfx}.self_attn.out_proj.bias"] = mx.array(
-            state_dict[f"{pt_pfx}.self_attn.out_proj.bias"].numpy()
-        )
-
-        for name in ["linear1", "linear2"]:
-            for param in ["weight", "bias"]:
-                weights[f"{mx_pfx}.{name}.{param}"] = mx.array(
-                    state_dict[f"{pt_pfx}.{name}.{param}"].numpy()
-                )
-
-        for name in ["norm1", "norm2"]:
-            for param in ["weight", "bias"]:
-                weights[f"{mx_pfx}.{name}.{param}"] = mx.array(
-                    state_dict[f"{pt_pfx}.{name}.{param}"].numpy()
-                )
-
-    return weights
-
-
-def _convert_projector_weights(state_dict: dict) -> dict:
-    """Convert PyTorch MLPProjector state_dict to MLX format.
-
-    TODO: Remove once checkpoints are pre-converted to safetensors.
-    """
-    return {
-        "norm.weight": mx.array(state_dict["projector.0.weight"].numpy()),
-        "norm.bias": mx.array(state_dict["projector.0.bias"].numpy()),
-        "linear.weight": mx.array(state_dict["projector.1.weight"].numpy()),
-        "linear.bias": mx.array(state_dict["projector.1.bias"].numpy()),
-    }


### PR DESCRIPTION
## Name of the PR
Remove runtime torch/peft by pre-converting checkpoints to safetensors

## :recycle: Current situation & Problem
Inference currently depended on torch + peft at runtime only to convert `.pt` checkpoint weights while loading.
This PR moves that conversion to a one-time offline step and keeps inference runtime MLX-only.

Related:
- No linked issue in this branch yet.

## :gear: Release Notes
- Added a one-time conversion utility: `convert_checkpoint.py`
- Converts checkpoint weights into MLX-ready safetensors files:
  - encoder conversion (Conv1d transpose, fused QKV split, key renaming)
  - projector key remap
  - LoRA key remap + transpose
- Updated runtime loading to read safetensors directly with `mx.load()`
- Removed runtime `torch` and `peft` dependencies from `requirements.txt`
- Updated default checkpoint argument to use a prefix instead of `.pt`

Migration:
- Before running inference, convert each `.pt` checkpoint once:
  - `python convert_checkpoint.py --input checkpoints/model_checkpoint.pt --output-prefix checkpoints/model_checkpoint`
- Runtime now expects:
  - `checkpoints/model_checkpoint.encoder.safetensors`
  - `checkpoints/model_checkpoint.projector.safetensors`
  - `checkpoints/model_checkpoint.lora.safetensors` (optional)

Breaking change:
- Yes, checkpoint input format at runtime changed from `.pt` to safetensors prefix.

## :books: Documentation
- README updated with one-time conversion workflow and expected output files.
- Inference usage now reflects the safetensors checkpoint prefix flow.

## :white_check_mark: Testing
- Verified code changes for Python diagnostics (no editor-reported errors in modified files).
- No new unit/integration tests were added in this commit.
- Functional validation expected by running conversion once and then running inference with converted files.

### Code of Conduct & Contributing Guidelines
- [x] I agree to follow the Code of Conduct and Contributing Guidelines.
